### PR TITLE
Add GrandparentTitle and ParentTitle to Webhook Metadata

### DIFF
--- a/webhook.go
+++ b/webhook.go
@@ -39,6 +39,8 @@ type Webhook struct {
 		Title                string `json:"title"`
 		GrandparentKey       string `json:"grandparentKey"`
 		ParentKey            string `json:"parentKey"`
+		GrandparentTitle     string `json:"grandparentTitle"`
+		ParentTitle          string `json:"parentTitle"`
 		Summary              string `json:"summary"`
 		Index                int    `json:"index"`
 		ParentIndex          int    `json:"parentIndex"`


### PR DESCRIPTION
The [plex webhook](https://support.plex.tv/hc/en-us/articles/115002267687) payload `Metadata` includes `grandparentTitle` and `parentTitle` fields for artist/series and album/season titles, respectively.