### PR TITLE
Created a way to aquire a plex token via sign in instead

### DIFF
--- a/models.go
+++ b/models.go
@@ -729,7 +729,7 @@ type User struct {
 	Entitlements []string `json:"entitlements"`
 	ConfirmedAt  string   `json:"confirmedAt"`
 	ForumID      int      `json:"forumId"`
-	RemeberMe    bool     `json:"rememberMe"`
+	RememberMe   bool     `json:"rememberMe"`
 }
 
 type SignInResponse struct {

--- a/models.go
+++ b/models.go
@@ -709,6 +709,33 @@ type BaseAPIResponse struct {
 	Version                       string `json:"version"`
 }
 
+type User struct {
+	ID           int    `json:"id"`
+	UUID         string `json:"uuid"`
+	Email        string `json:"email"`
+	JoinedAt     string `json:"joined_at"`
+	Username     string `json:"username"`
+	Thumb        string `json:"thumb"`
+	AuthToken    string `json:"authToken"`
+	Subscription struct {
+		Active   bool     `json:"active"`
+		Status   string   `json:"Active"`
+		Plan     string   `json:"lifetime"`
+		Features []string `json:"features"`
+	} `json:"subscription"`
+	Roles struct {
+		Roles []string `json:"roles"`
+	} `json:"roles"`
+	Entitlements []string `json:"entitlements"`
+	ConfirmedAt  string   `json:"confirmedAt"`
+	ForumID      int      `json:"forumId"`
+	RemeberMe    bool     `json:"rememberMe"`
+}
+
+type SignInResponse struct {
+	User User `json:"user"`
+}
+
 // ServerInfo is the result of the https://plex.tv/api/servers endpoint
 type ServerInfo struct {
 	XMLName           xml.Name `xml:"MediaContainer"`

--- a/plex.go
+++ b/plex.go
@@ -57,7 +57,9 @@ func SignIn(baseURL, username, password string) (*Plex, error) {
 		return &Plex{}, errors.New("url is required")
 	}
 
-	_, err := url.ParseRequestURI(baseURL)
+	if _, err := url.ParseRequestURI(baseURL); err != nil {
+		return &Plex{}, err
+	}
 
 	p := Plex{
 		URL: baseURL,
@@ -90,7 +92,7 @@ func SignIn(baseURL, username, password string) (*Plex, error) {
 
 	var signInResponse SignInResponse
 
-	err = json.Unmarshal(bodyBytes, &signInResponse)
+	err := json.Unmarshal(bodyBytes, &signInResponse)
 	if err != nil {
 		return &Plex{}, err
 	}

--- a/plex.go
+++ b/plex.go
@@ -19,15 +19,16 @@ const plexURL = "https://plex.tv"
 
 func defaultHeaders() headers {
 	return headers{
-		Platform:        runtime.GOOS,
-		PlatformVersion: "0.0.0",
-		Product:         "Go Plex Client",
-		Version:         "0.0.1",
-		Device:          runtime.GOOS + " " + runtime.GOARCH,
-		ContainerSize:   "Plex-Container-Size=50",
-		ContainerStart:  "X-Plex-Container-Start=0",
-		Accept:          "application/json",
-		ContentType:     "application/json",
+		Platform:         runtime.GOOS,
+		PlatformVersion:  "0.0.0",
+		Product:          "Go Plex Client",
+		Version:          "0.0.1",
+		Device:           runtime.GOOS + " " + runtime.GOARCH,
+		ContainerSize:    "Plex-Container-Size=50",
+		ContainerStart:   "X-Plex-Container-Start=0",
+		Accept:           "application/json",
+		ContentType:      "application/json",
+		ClientIdentifier: "goplexclient", // This should be generated as a UUID for each client
 	}
 }
 
@@ -47,6 +48,55 @@ func New(baseURL, token string) (*Plex, error) {
 			Timeout: 3 * time.Second,
 		},
 	}, err
+}
+
+// Creates a plex instance using a user name and password instead of an auth
+// token.
+func SignIn(baseURL, username, password string) (*Plex, error) {
+	if baseURL == "" {
+		return &Plex{}, errors.New("url is required")
+	}
+
+	_, err := url.ParseRequestURI(baseURL)
+
+	p := Plex{
+		URL: baseURL,
+		HTTPClient: http.Client{
+			Timeout: 3 * time.Second,
+		},
+	}
+
+	query := p.URL + "/users/sign_in.json"
+
+	// Encode login in the specific format they require
+	body := url.Values{}
+	body.Add("user[login]", username)
+	body.Add("user[password]", password)
+
+	newHeaders := defaultHeaders()
+	// Doesn't like having a content type, even form-data
+	newHeaders.ContentType = ""
+	resp, respErr := p.post(query, []byte(body.Encode()), newHeaders)
+
+	if respErr != nil {
+		return &Plex{}, respErr
+	}
+	if resp.StatusCode != 201 {
+		return &Plex{}, errors.New(resp.Status)
+	}
+
+	bodyBytes, _ := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+
+	var signInResponse SignInResponse
+
+	err = json.Unmarshal(bodyBytes, &signInResponse)
+	if err != nil {
+		return &Plex{}, err
+	}
+	p.Token = signInResponse.User.AuthToken
+
+	return &p, err
 }
 
 // Search your Plex Server for media

--- a/plex_test.go
+++ b/plex_test.go
@@ -49,6 +49,22 @@ func newTestServer(code int, body string) (*httptest.Server, *Plex) {
 	return server, plex
 }
 
+func TestSignIn(t *testing.T) {
+	username := os.Getenv("PLEX_USERNAME")
+	password := os.Getenv("PLEX_PASSWORD")
+	plex, err := SignIn(plexURL, username, password)
+
+	if err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	if plex.Token == "" {
+		t.Error("Received an empty token")
+		return
+	}
+}
+
 func TestGetSessions(t *testing.T) {
 	testData := string(`
     <MediaContainer size="2">


### PR DESCRIPTION
Adds a way to create a plex instance with a plex.tv username and password by requesting a token according to [this](https://forums.plex.tv/discussion/129922/how-to-request-a-x-plex-token-token-for-your-app/p1) specification.

Technically, the client identification needs to be a unique identifier though I'm not sure how best to do that. 

I don't write much go code so be gentle...