### PR TITLE
updated cli

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -22,6 +23,23 @@ var (
 	// appSecret will used to seed encrypt()
 	appSecret = []byte("iAmAseCReTuSEdTOENcrYp")
 )
+
+type server struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+func (s server) Serialize() ([]byte, error) {
+	return json.Marshal(s)
+}
+
+func unserializeServer(serializedServer []byte) (server, error) {
+	var s server
+
+	err := json.Unmarshal(serializedServer, &s)
+
+	return s, err
+}
 
 func main() {
 	app := cli.NewApp()
@@ -116,19 +134,7 @@ func main() {
 		{
 			Name:   "library",
 			Usage:  "display your libraries",
-			Action: getLibraries,
-			Flags: []cli.Flag{
-				cli.StringFlag{
-					Name:  "token",
-					Value: "",
-					Usage: "plex token is required to access your server",
-				},
-				cli.StringFlag{
-					Name:  "url",
-					Value: "",
-					Usage: "url to your plex server",
-				},
-			},
+			Action: getLibraries(db),
 		},
 		{
 			Name:   "request-pin",
@@ -155,6 +161,11 @@ func main() {
 			Name:   "signin",
 			Usage:  "use your username and password to receive a plex auth token",
 			Action: signIn(db),
+		},
+		{
+			Name:   "pick-server",
+			Usage:  "choose a server to interact with",
+			Action: pickServer(db),
 		},
 	}
 

--- a/models.go
+++ b/models.go
@@ -625,29 +625,34 @@ type terminateSessionResponse struct {
 
 // PMSDevices is the result of the https://plex.tv/pms/resources endpoint
 type PMSDevices struct {
-	Name                 string `json:"name" xml:"name,attr"`
-	Product              string `json:"product" xml:"product,attr"`
-	ProductVersion       string `json:"productVersion" xml:"productVersion,attr"`
-	Platform             string `json:"platform" xml:"platform,attr"`
-	PlatformVersion      string `json:"platformVersion" xml:"platformVersion,attr"`
-	Device               int    `json:"device" xml:"device,attr"`
-	ClientIdentifier     string `json:"clientIdentifier" xml:"clientIdentifier,attr"`
-	CreatedAt            string `json:"createdAt" xml:"createdAt,attr"`
-	LastSeenAt           string `json:"lastSeenAt" xml:"lastSeenAt,attr"`
-	Provides             string `json:"provides" xml:"provides,attr"`
-	Owned                string `json:"owned" xml:"owned,attr"`
-	AccessToken          string `json:"accessToken" xml:"accessToken,attr"`
-	HTTPSRequired        string `json:"httpsRequired" xml:"httpsRequired,attr"`
-	Synced               string `json:"synced" xml:"synced,attr"`
-	PublicAddressMatches string `json:"publicAddressMatches" xml:"publicAddressMatches,attr"`
-	Presence             string `json:"presence" xml:"presence,attr"`
-	Connection           []struct {
-		Protocol string `json:"protocol" xml:"protocol,attr"`
-		Address  string `json:"address" xml:"address,attr"`
-		Port     string `json:"port" xml:"port,attr"`
-		URI      string `json:"uri" xml:"uri,attr"`
-		Local    int    `json:"local" xml:"local,attr"`
-	} `json:"connection" xml:"Connection"`
+	Name                 string       `json:"name" xml:"name,attr"`
+	Product              string       `json:"product" xml:"product,attr"`
+	ProductVersion       string       `json:"productVersion" xml:"productVersion,attr"`
+	Platform             string       `json:"platform" xml:"platform,attr"`
+	PlatformVersion      string       `json:"platformVersion" xml:"platformVersion,attr"`
+	Device               string       `json:"device" xml:"device,attr"`
+	ClientIdentifier     string       `json:"clientIdentifier" xml:"clientIdentifier,attr"`
+	CreatedAt            string       `json:"createdAt" xml:"createdAt,attr"`
+	LastSeenAt           string       `json:"lastSeenAt" xml:"lastSeenAt,attr"`
+	Provides             string       `json:"provides" xml:"provides,attr"`
+	Owned                string       `json:"owned" xml:"owned,attr"`
+	AccessToken          string       `json:"accessToken" xml:"accessToken,attr"`
+	HTTPSRequired        int          `json:"httpsRequired" xml:"httpsRequired,attr"`
+	Synced               string       `json:"synced" xml:"synced,attr"`
+	Relay                int          `json:"relay" xml:"relay,attr"`
+	PublicAddressMatches string       `json:"publicAddressMatches" xml:"publicAddressMatches,attr"`
+	PublicAddress        string       `json:"publicAddress" xml:"publicAddress,attr"`
+	Presence             string       `json:"presence" xml:"presence,attr"`
+	Connection           []Connection `json:"connection" xml:"Connection"`
+}
+
+// Connection lists options to connect to a device
+type Connection struct {
+	Protocol string `json:"protocol" xml:"protocol,attr"`
+	Address  string `json:"address" xml:"address,attr"`
+	Port     string `json:"port" xml:"port,attr"`
+	URI      string `json:"uri" xml:"uri,attr"`
+	Local    int    `json:"local" xml:"local,attr"`
 }
 
 // BaseAPIResponse info about the Plex Media Server


### PR DESCRIPTION
In the command-line tool, the user can pick their server once signed in

Updated `plex.New()` to be able to take an empty url or token