### PR TITLE
Set default headers when constructing a new Plex client

### DIFF
--- a/plex.go
+++ b/plex.go
@@ -51,6 +51,7 @@ func New(baseURL, token string) (*Plex, error) {
 		Timeout: 3 * time.Second,
 	}
 
+	p.Headers = defaultHeaders()
 	// id, err := uuid.NewRandom()
 
 	// if err != nil {


### PR DESCRIPTION
As of the latest commit any call that relies on a json response from the Plex API breaks because the call to `defaultHeaders()` was removed.