### PR TITLE
Fix CLI test command to read the token

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -82,8 +82,10 @@ func test(c *cli.Context) error {
 		}
 
 		host = _host.String()
+		token = args[0]
 	} else {
 		host = hostParsed.String()
+		token = args[1]
 	}
 
 	plexConn, err := plex.New(host, token)


### PR DESCRIPTION
The `test` subcommand of the cli never set the token variable. Use whatever argument wasn't the URL to fill the token.