### PR TITLE
websockets: Return from writer thread after close finished

### DIFF
--- a/websocket_client.go
+++ b/websocket_client.go
@@ -257,10 +257,10 @@ func (p *Plex) SubscribeToNotifications(events *NotificationEvents, interrupt <-
 				select {
 				case <-done:
 				case <-time.After(time.Second):
+					fmt.Println("closing websocket...")
+					c.Close()
 				}
-				fmt.Println("closing websocket...")
-				c.Close()
-				break
+				return
 			}
 		}
 	}()


### PR DESCRIPTION
When an interrupt arrived, the writer thread sends a CloseMessage, the reader thread receives confirmation and nicely shuts down, closing the done channel and the websocket. If that happens within one second, the writer thread needs to return rather than continuing in the loop. If that didn't happen within one second, only then it's useful for the writer thread to call c.Close() as well.

The most important fix is changing break to return, to avoid leaking the writer thread and having it fail every second.