### PR TITLE
Scrobble

### DIFF
--- a/plex.go
+++ b/plex.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"regexp"
 	"runtime"
 	"strconv"
 	"time"

--- a/plex.go
+++ b/plex.go
@@ -1157,3 +1157,48 @@ func (p *Plex) TerminateSession(sessionID string, reason string) error {
 
 	return nil
 }
+
+// Scrobble sets watched status of KEY to watched
+func (p *Plex) Scrobble(key string) error {
+	re, _ := regexp.Compile("([0-9]+)")
+	keynumber := re.FindString(key)
+
+	query := fmt.Sprintf("%s/:/scrobble?identifier=com.plexapp.plugins.library&key=%s", p.URL, keynumber)
+
+	resp, err := p.get(query, p.Headers)
+
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return errors.New(resp.Status)
+	}
+
+	return nil
+}
+
+// Unscrobble sets watched status of KEY to unwatched
+func (p *Plex) Unscrobble(key string) error {
+
+	re, _ := regexp.Compile("([0-9]+)")
+	keynumber := re.FindString(key)
+
+	query := fmt.Sprintf("%s/:/unscrobble?identifier=com.plexapp.plugins.library&key=%s", p.URL, keynumber)
+
+	resp, err := p.get(query, p.Headers)
+
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return errors.New(resp.Status)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Scrobble und Unscrobble allows to set a mediaitem to watched or unwatched
key can be the simple number (as string), or the direct value from a metadata search result (something like "/library/metadata/12345")