### PR TITLE
AltGUIDs field in Metadata struct

### DIFF
--- a/models.go
+++ b/models.go
@@ -54,6 +54,7 @@ type Metadata struct {
 	GrandparentThumb      string       `json:"grandparentThumb"`
 	GrandparentTitle      string       `json:"grandparentTitle"`
 	GUID                  string       `json:"guid"`
+	AltGUIDs              []AltGUID    `json:"Guid"`
 	Index                 int64        `json:"index"`
 	Key                   string       `json:"key"`
 	LastViewedAt          int          `json:"lastViewedAt"`
@@ -82,6 +83,11 @@ type Metadata struct {
 	Year                  int          `json:"year"`
 	Director              []TaggedData `json:"Director"`
 	Writer                []TaggedData `json:"Writer"`
+}
+
+// AltGUID represents a Globally Unique Identifier for a metadata provider that is not actively being used.
+type AltGUID struct {
+	ID string `json:"id"`
 }
 
 // MetadataV1 ...


### PR DESCRIPTION
Due to a recent change, some queries for metadata can fail with the error `json: cannot unmarshal array into Go struct field Metadata.MediaContainer.Metadata.guid of type string`.

This PR fixes this issue by defining a struct and a field to handle the new `Guid` field.