### PR TITLE
Download implementation

### DIFF
--- a/models.go
+++ b/models.go
@@ -15,6 +15,7 @@ type Plex struct {
 	ClientIdentifier string
 	Headers          headers
 	HTTPClient       http.Client
+	DownloadClient   http.Client
 }
 
 // SearchResults a list of media returned when searching

--- a/utils.go
+++ b/utils.go
@@ -24,6 +24,41 @@ import (
 // 	return resp, nil
 // }
 
+func (p *Plex) grab(query string, h headers) (*http.Response, error) {
+	client := p.DownloadClient
+
+	req, reqErr := http.NewRequest("GET", query, nil)
+
+	if reqErr != nil {
+		return &http.Response{}, reqErr
+	}
+
+	req.Header.Add("Accept", h.Accept)
+	req.Header.Add("X-Plex-Platform", h.Platform)
+	req.Header.Add("X-Plex-Platform-Version", h.PlatformVersion)
+	req.Header.Add("X-Plex-Provides", h.Provides)
+	req.Header.Add("X-Plex-Client-Identifier", p.ClientIdentifier)
+	req.Header.Add("X-Plex-Product", h.Product)
+	req.Header.Add("X-Plex-Version", h.Version)
+	req.Header.Add("X-Plex-Device", h.Device)
+	// req.Header.Add("X-Plex-Container-Size", h.ContainerSize)
+	// req.Header.Add("X-Plex-Container-Start", h.ContainerStart)
+	req.Header.Add("X-Plex-Token", p.Token)
+
+	// optional headers
+	if h.TargetClientIdentifier != "" {
+		req.Header.Add("X-Plex-Target-Identifier", h.TargetClientIdentifier)
+	}
+
+	resp, err := client.Do(req)
+
+	if err != nil {
+		return &http.Response{}, err
+	}
+
+	return resp, nil
+}
+
 func (p *Plex) get(query string, h headers) (*http.Response, error) {
 	client := p.HTTPClient
 


### PR DESCRIPTION
Those three commits should bring the Download feature to the client as mentioned by #36 

- Addition of an http.Client to the Plex struct to allow longer GET request and thus be able to download media.
- Addition of a "grab" request that uses that particular client
- Addition of a Download function that downloads the different "parts" of the different media of one metadata.