### PR TITLE
Download enhancements

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -895,6 +895,10 @@ func downloadMedia(c *cli.Context) error {
 		downloadPath = "."
 	}
 
+	createFolders := c.Bool("folders")
+
+	skipIfExists := c.Bool("skip")
+
 	// search for media
 	results, err := plexConn.Search(c.Args().First())
 
@@ -927,7 +931,7 @@ func downloadMedia(c *cli.Context) error {
 	selectedMedia := results.MediaContainer.Metadata[selection]
 
 	// download media
-	if err := plexConn.Download(selectedMedia, downloadPath); err != nil {
+	if err := plexConn.Download(selectedMedia, downloadPath, createFolders, skipIfExists); err != nil {
 		return cli.NewExitError(err, 1)
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -153,6 +153,16 @@ func main() {
 			Name:   "download",
 			Usage:  "download media from your plex server",
 			Action: downloadMedia,
+			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:  "folders",
+					Usage: "create folder hierarchy",
+				},
+				cli.BoolFlag{
+					Name:  "skip",
+					Usage: "skip download if file already exists",
+				},
+			},
 		},
 	}
 

--- a/plex.go
+++ b/plex.go
@@ -324,7 +324,7 @@ func (p *Plex) GetOnDeck() (SearchResultsEpisode, error) {
 }
 
 // Download media associated with metadata
-func (p *Plex) Download(meta Metadata, path string, createFolders bool) error {
+func (p *Plex) Download(meta Metadata, path string, createFolders bool, skipIfExists bool) error {
 
 	path = filepath.Join(path)
 	if createFolders {
@@ -348,6 +348,12 @@ func (p *Plex) Download(meta Metadata, path string, createFolders bool) error {
 			file := split[len(split)-1]
 
 			fp := filepath.Join(path, file)
+
+			_, exists := os.Stat(fp)
+
+			if exists == nil && skipIfExists {
+				return nil
+			}
 
 			query := fmt.Sprintf("%s%s?download=1", p.URL, part.Key)
 

--- a/plex.go
+++ b/plex.go
@@ -326,6 +326,10 @@ func (p *Plex) GetOnDeck() (SearchResultsEpisode, error) {
 // Download media associated with metadata
 func (p *Plex) Download(meta Metadata, path string, createFolders bool, skipIfExists bool) error {
 
+	if len(meta.Media) == 0 {
+		return fmt.Errorf("no media associated with metadata, skipping")
+	}
+
 	path = filepath.Join(path)
 	if createFolders {
 

--- a/plex.go
+++ b/plex.go
@@ -324,9 +324,20 @@ func (p *Plex) GetOnDeck() (SearchResultsEpisode, error) {
 }
 
 // Download media associated with metadata
-func (p *Plex) Download(meta Metadata, path string) error {
+func (p *Plex) Download(meta Metadata, path string, createFolders bool) error {
 
 	path = filepath.Join(path)
+	if createFolders {
+
+		if meta.ParentTitle != "" && meta.GrandparentTitle != "" { // for tv shows and music
+			path = filepath.Join(path, meta.GrandparentTitle, meta.ParentTitle)
+		} else { // for movies
+			path = filepath.Join(path, meta.Title)
+		}
+		if err := os.MkdirAll(path, 0700); err != nil {
+			return err
+		}
+	}
 
 	for _, media := range meta.Media {
 

--- a/plex.go
+++ b/plex.go
@@ -335,9 +335,8 @@ func (p *Plex) Download(meta Metadata, path string) error {
 			// get original filename from original path
 			split := strings.Split(part.File, "/")
 			file := split[len(split)-1]
-			// compute filepath
-			fp := fmt.Sprintf("%s/%s", path, file)
-			fp = filepath.Join(fp)
+
+			fp := filepath.Join(path, file)
 
 			query := fmt.Sprintf("%s%s?download=1", p.URL, part.Key)
 


### PR DESCRIPTION
This pull request adds two options to the download feature:
- an option to create folder hierarchy as mentioned in #39 (passed to function as boolean `createFolders`) &
- an option to skip download if the file already exists in the same path (passed to function as boolean `skipIfExists`).

Furthermore, the CLI download command has been updated with two flags to represent those options, respectively `--folders` and `--skip`.

