### PR TITLE
Fix json error on SignIn() 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 plex
 vendor/*
-
+*.sh
 .idea

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -860,6 +861,42 @@ func getMetadata(c *cli.Context) error {
 	}
 
 	result, err := plexConn.GetMetadata(c.Args().First())
+
+	if err != nil {
+		return cli.NewExitError(err, 1)
+	}
+
+	fmt.Println(result)
+
+	return nil
+}
+
+func getPlaylist(c *cli.Context) error {
+	db, err := startDB()
+
+	if err != nil {
+		return cli.NewExitError(err, 1)
+	}
+
+	defer db.Close()
+
+	plexConn, err := initPlex(db, true, true)
+
+	if err != nil {
+		return err
+	}
+
+	if c.NArg() == 0 {
+		return cli.NewExitError("playlist id is required", 1)
+	}
+
+	playlistID, err := strconv.ParseInt(c.Args().First(), 10, 64)
+
+	if err != nil {
+		return cli.NewExitError(err, 1)
+	}
+
+	result, err := plexConn.GetPlaylist(int(playlistID))
 
 	if err != nil {
 		return cli.NewExitError(err, 1)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -149,6 +149,11 @@ func main() {
 			Usage:  "get metadata of media on plex server",
 			Action: getMetadata,
 		},
+		{
+			Name:   "playlist",
+			Usage:  "print playlsit items on plex server",
+			Action: getPlaylist,
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {

--- a/error_types.go
+++ b/error_types.go
@@ -14,4 +14,5 @@ const (
 	ErrorPINNotAuthorized   = "pin is not authorized yet"
 	ErrorLinkAccount        = "failed to link account: %s"
 	ErrorFailedToSetWebhook = "failed to set webhook"
+	ErrorWebhook            = "webhook error: %s"
 )

--- a/models.go
+++ b/models.go
@@ -58,7 +58,7 @@ type Metadata struct {
 	Index                 int64        `json:"index"`
 	Key                   string       `json:"key"`
 	LastViewedAt          int          `json:"lastViewedAt"`
-	LibrarySectionID      string       `json:"librarySectionID"`
+	LibrarySectionID      json.Number  `json:"librarySectionID"`
 	LibrarySectionKey     string       `json:"librarySectionKey"`
 	LibrarySectionTitle   string       `json:"librarySectionTitle"`
 	OriginallyAvailableAt string       `json:"originallyAvailableAt"`
@@ -92,24 +92,24 @@ type AltGUID struct {
 
 // Media media info
 type Media struct {
-	AspectRatio           float32 `json:"aspectRatio"`
-	AudioChannels         int     `json:"audioChannels"`
-	AudioCodec            string  `json:"audioCodec"`
-	AudioProfile          string  `json:"audioProfile"`
-	Bitrate               int     `json:"bitrate"`
-	Container             string  `json:"container"`
-	Duration              int     `json:"duration"`
-	Has64bitOffsets       bool    `json:"has64bitOffsets"`
-	Height                int     `json:"height"`
-	ID                    string  `json:"id"`
-	OptimizedForStreaming bool    `json:"optimizedForStreaming"`
-	Selected              bool    `json:"selected"`
-	VideoCodec            string  `json:"videoCodec"`
-	VideoFrameRate        string  `json:"videoFrameRate"`
-	VideoProfile          string  `json:"videoProfile"`
-	VideoResolution       string  `json:"videoResolution"`
-	Width                 int     `json:"width"`
-	Part                  []Part  `json:"Part"`
+	AspectRatio           json.Number `json:"aspectRatio"`
+	AudioChannels         int         `json:"audioChannels"`
+	AudioCodec            string      `json:"audioCodec"`
+	AudioProfile          string      `json:"audioProfile"`
+	Bitrate               int         `json:"bitrate"`
+	Container             string      `json:"container"`
+	Duration              int         `json:"duration"`
+	Has64bitOffsets       bool        `json:"has64bitOffsets"`
+	Height                int         `json:"height"`
+	ID                    json.Number `json:"id"`
+	OptimizedForStreaming bool        `json:"optimizedForStreaming"` // plex can return int or boolean: 0 or 1; true or false
+	Selected              bool        `json:"selected"`
+	VideoCodec            string      `json:"videoCodec"`
+	VideoFrameRate        string      `json:"videoFrameRate"`
+	VideoProfile          string      `json:"videoProfile"`
+	VideoResolution       string      `json:"videoResolution"`
+	Width                 int         `json:"width"`
+	Part                  []Part      `json:"Part"`
 }
 
 // MediaContainer contains media info
@@ -731,67 +731,67 @@ type TranscodeSessionsResponse struct {
 
 // Stream ...
 type Stream struct {
-	AlbumGain          string  `json:"albumGain"`
-	AlbumPeak          string  `json:"albumPeak"`
-	AlbumRange         string  `json:"albumRange"`
-	Anamorphic         bool    `json:"anamorphic"`
-	AudioChannelLayout string  `json:"audioChannelLayout"`
-	BitDepth           int     `json:"bitDepth"`
-	Bitrate            int     `json:"bitrate"`
-	BitrateMode        string  `json:"bitrateMode"`
-	Cabac              string  `json:"cabac"`
-	Channels           int     `json:"channels"`
-	ChromaLocation     string  `json:"chromaLocation"`
-	ChromaSubsampling  string  `json:"chromaSubsampling"`
-	Codec              string  `json:"codec"`
-	CodecID            string  `json:"codecID"`
-	ColorRange         string  `json:"colorRange"`
-	ColorSpace         string  `json:"colorSpace"`
-	Default            bool    `json:"default"`
-	DisplayTitle       string  `json:"displayTitle"`
-	Duration           string  `json:"duration"`
-	FrameRate          float64 `json:"frameRate"`
-	FrameRateMode      string  `json:"frameRateMode"`
-	Gain               string  `json:"gain"`
-	HasScalingMatrix   bool    `json:"hasScalingMatrix"`
-	Height             int     `json:"height"`
-	ID                 string  `json:"id"`
-	Index              int     `json:"index"`
-	Language           string  `json:"language"`
-	LanguageCode       string  `json:"languageCode"`
-	Level              int     `json:"level"`
-	Location           string  `json:"location"`
-	Loudness           string  `json:"loudness"`
-	Lra                string  `json:"lra"`
-	Peak               string  `json:"peak"`
-	PixelAspectRatio   string  `json:"pixelAspectRatio"`
-	PixelFormat        string  `json:"pixelFormat"`
-	Profile            string  `json:"profile"`
-	RefFrames          int     `json:"refFrames"`
-	SamplingRate       int     `json:"samplingRate"`
-	ScanType           string  `json:"scanType"`
-	Selected           bool    `json:"selected"`
-	StreamIdentifier   string  `json:"streamIdentifier"`
-	StreamType         int     `json:"streamType"`
-	Width              int     `json:"width"`
+	AlbumGain          string      `json:"albumGain"`
+	AlbumPeak          string      `json:"albumPeak"`
+	AlbumRange         string      `json:"albumRange"`
+	Anamorphic         bool        `json:"anamorphic"`
+	AudioChannelLayout string      `json:"audioChannelLayout"`
+	BitDepth           int         `json:"bitDepth"`
+	Bitrate            int         `json:"bitrate"`
+	BitrateMode        string      `json:"bitrateMode"`
+	Cabac              string      `json:"cabac"`
+	Channels           int         `json:"channels"`
+	ChromaLocation     string      `json:"chromaLocation"`
+	ChromaSubsampling  string      `json:"chromaSubsampling"`
+	Codec              string      `json:"codec"`
+	CodecID            string      `json:"codecID"`
+	ColorRange         string      `json:"colorRange"`
+	ColorSpace         string      `json:"colorSpace"`
+	Default            bool        `json:"default"`
+	DisplayTitle       string      `json:"displayTitle"`
+	Duration           string      `json:"duration"`
+	FrameRate          float64     `json:"frameRate"`
+	FrameRateMode      string      `json:"frameRateMode"`
+	Gain               string      `json:"gain"`
+	HasScalingMatrix   bool        `json:"hasScalingMatrix"`
+	Height             int         `json:"height"`
+	ID                 json.Number `json:"id"`
+	Index              int         `json:"index"`
+	Language           string      `json:"language"`
+	LanguageCode       string      `json:"languageCode"`
+	Level              int         `json:"level"`
+	Location           string      `json:"location"`
+	Loudness           string      `json:"loudness"`
+	Lra                string      `json:"lra"`
+	Peak               string      `json:"peak"`
+	PixelAspectRatio   string      `json:"pixelAspectRatio"`
+	PixelFormat        string      `json:"pixelFormat"`
+	Profile            string      `json:"profile"`
+	RefFrames          int         `json:"refFrames"`
+	SamplingRate       int         `json:"samplingRate"`
+	ScanType           string      `json:"scanType"`
+	Selected           bool        `json:"selected"`
+	StreamIdentifier   string      `json:"streamIdentifier"`
+	StreamType         int         `json:"streamType"`
+	Width              int         `json:"width"`
 }
 
 // Part ...
 type Part struct {
-	AudioProfile          string   `json:"audioProfile"`
-	Container             string   `json:"container"`
-	Decision              string   `json:"decision"`
-	Duration              int      `json:"duration"`
-	File                  string   `json:"file"`
-	Has64bitOffsets       bool     `json:"has64bitOffsets"`
-	HasThumbnail          string   `json:"hasThumbnail"`
-	ID                    string   `json:"id"`
-	Key                   string   `json:"key"`
-	OptimizedForStreaming bool     `json:"optimizedForStreaming"`
-	Selected              bool     `json:"selected"`
-	Size                  int      `json:"size"`
-	Stream                []Stream `json:"Stream"`
-	VideoProfile          string   `json:"videoProfile"`
+	AudioProfile          string      `json:"audioProfile"`
+	Container             string      `json:"container"`
+	Decision              string      `json:"decision"`
+	Duration              int         `json:"duration"`
+	File                  string      `json:"file"`
+	Has64bitOffsets       bool        `json:"has64bitOffsets"`
+	HasThumbnail          string      `json:"hasThumbnail"`
+	ID                    json.Number `json:"id"`
+	Key                   string      `json:"key"`
+	OptimizedForStreaming bool        `json:"optimizedForStreaming"`
+	Selected              bool        `json:"selected"`
+	Size                  int         `json:"size"`
+	Stream                []Stream    `json:"Stream"`
+	VideoProfile          string      `json:"videoProfile"`
 }
 
 // Player ...

--- a/models.go
+++ b/models.go
@@ -58,7 +58,7 @@ type Metadata struct {
 	Index                 int64        `json:"index"`
 	Key                   string       `json:"key"`
 	LastViewedAt          int          `json:"lastViewedAt"`
-	LibrarySectionID      int          `json:"librarySectionID"`
+	LibrarySectionID      string       `json:"librarySectionID"`
 	LibrarySectionKey     string       `json:"librarySectionKey"`
 	LibrarySectionTitle   string       `json:"librarySectionTitle"`
 	OriginallyAvailableAt string       `json:"originallyAvailableAt"`
@@ -90,22 +90,6 @@ type AltGUID struct {
 	ID string `json:"id"`
 }
 
-// MetadataV1 ...
-type MetadataV1 struct {
-	Metadata
-	Index            int64     `json:"index,string"`
-	ParentIndex      int64     `json:"parentIndex,string"`
-	AddedAt          string    `json:"addedAt"`
-	Duration         string    `json:"duration"`
-	LastViewedAt     string    `json:"lastViewedAt"`
-	LibrarySectionID string    `json:"librarySectionID"`
-	Media            []MediaV1 `json:"Media"`
-	Rating           string    `json:"rating"`
-	UpdatedAt        string    `json:"updatedAt"`
-	ViewOffset       string    `json:"viewOffset"`
-	Year             string    `json:"year"`
-}
-
 // Media media info
 type Media struct {
 	AspectRatio           float32 `json:"aspectRatio"`
@@ -117,8 +101,8 @@ type Media struct {
 	Duration              int     `json:"duration"`
 	Has64bitOffsets       bool    `json:"has64bitOffsets"`
 	Height                int     `json:"height"`
-	ID                    int     `json:"id"`
-	OptimizedForStreaming int     `json:"optimizedForStreaming"`
+	ID                    string  `json:"id"`
+	OptimizedForStreaming bool    `json:"optimizedForStreaming"`
 	Selected              bool    `json:"selected"`
 	VideoCodec            string  `json:"videoCodec"`
 	VideoFrameRate        string  `json:"videoFrameRate"`
@@ -126,21 +110,6 @@ type Media struct {
 	VideoResolution       string  `json:"videoResolution"`
 	Width                 int     `json:"width"`
 	Part                  []Part  `json:"Part"`
-}
-
-// MediaV1 media information version 1
-type MediaV1 struct {
-	Media
-	Part                  []PartV1 `json:"Part"`
-	AudioChannels         float32  `json:"audioChannels,string"`
-	AspectRatio           float32  `json:"aspectRatio,string"`
-	Bitrate               int      `json:"bitrate,string"`
-	Duration              int      `json:"duration,string"`
-	Has64bitOffsets       string   `json:"has64bitOffsets"`
-	Height                int      `json:"height,string"`
-	ID                    int      `json:"id,string"`
-	OptimizedForStreaming int      `json:"optimizedForStreaming,string"`
-	Width                 int      `json:"width,string"`
 }
 
 // MediaContainer contains media info
@@ -786,7 +755,7 @@ type Stream struct {
 	Gain               string  `json:"gain"`
 	HasScalingMatrix   bool    `json:"hasScalingMatrix"`
 	Height             int     `json:"height"`
-	ID                 int     `json:"id"`
+	ID                 string  `json:"id"`
 	Index              int     `json:"index"`
 	Language           string  `json:"language"`
 	LanguageCode       string  `json:"languageCode"`
@@ -807,26 +776,6 @@ type Stream struct {
 	Width              int     `json:"width"`
 }
 
-// StreamV1 stream info version 1
-type StreamV1 struct {
-	Stream
-	BitDepth         int     `json:"bitDepth,string"`
-	Default          string  `json:"default"`
-	Bitrate          int     `json:"bitrate,string"`
-	FrameRate        float64 `json:"frameRate,string"`
-	HasScalingMatrix string  `json:"hasScalingMatrix"`
-	Height           int     `json:"height,string"`
-	Width            int     `json:"width,string"`
-	ID               int     `json:"id,string"`
-	Index            int     `json:"index,string"`
-	Level            int     `json:"level,string"`
-	RefFrames        int     `json:"refFrames,string"`
-	StreamType       int     `json:"streamType,string"`
-	Channels         int     `json:"channels,string"`
-	SamplingRate     int     `json:"samplingRate,string"`
-	Selected         string  `json:"selected"`
-}
-
 // Part ...
 type Part struct {
 	AudioProfile          string   `json:"audioProfile"`
@@ -836,24 +785,13 @@ type Part struct {
 	File                  string   `json:"file"`
 	Has64bitOffsets       bool     `json:"has64bitOffsets"`
 	HasThumbnail          string   `json:"hasThumbnail"`
-	ID                    int      `json:"id"`
+	ID                    string   `json:"id"`
 	Key                   string   `json:"key"`
 	OptimizedForStreaming bool     `json:"optimizedForStreaming"`
 	Selected              bool     `json:"selected"`
 	Size                  int      `json:"size"`
 	Stream                []Stream `json:"Stream"`
 	VideoProfile          string   `json:"videoProfile"`
-}
-
-// PartV1 part version 1
-type PartV1 struct {
-	Part
-	Duration              int        `json:"duration,string"`
-	Has64bitOffsets       string     `json:"has64bitOffsets"`
-	ID                    int        `json:"id,string"`
-	OptimizedForStreaming string     `json:"optimizedForStreaming"`
-	Size                  int        `json:"size,string"`
-	Stream                []StreamV1 `json:"Stream"`
 }
 
 // Player ...
@@ -885,7 +823,7 @@ type Session struct {
 // CurrentSessions metadata of users consuming media
 type CurrentSessions struct {
 	MediaContainer struct {
-		Metadata []MetadataV1 `json:"Metadata"`
-		Size     int          `json:"size"`
+		Metadata []Metadata `json:"Metadata"`
+		Size     int        `json:"size"`
 	} `json:"MediaContainer"`
 }

--- a/models.go
+++ b/models.go
@@ -547,7 +547,15 @@ type UserPlexTV struct {
 		DefaultSubtitleAccessibility int64  `json:"defaultSubtitleAccessibility"`
 		DefaultSubtitleForced        int64  `json:"defaultSubtitleForced"`
 	} `json:"profile"`
-	Subscriptions        []string   `json:"subscriptions"`
+	Subscriptions []struct {
+		ID       int64  `json:"id"`
+		Mode     string `json:"mode"`
+		RenewsAt string `json:"renewsAt"` // can be null; not sure of type as I have lifetime membership
+		EndsAt   string `json:"endsAt"`   // can be null; not sure of type as I have lifetime membership
+		Type     string `json:"type"`
+		Transfer string `json:"transfer"` // can be null; not sure of type
+		State    string `json:"state"`
+	} `json:"subscriptions"`
 	PastSubscriptions    []string   `json:"pastSubscriptions"`
 	Trials               []string   `json:"trials"`
 	Services             []Services `json:"services"`

--- a/plex.go
+++ b/plex.go
@@ -328,8 +328,10 @@ func (p *Plex) GetPlaylist(key int) (SearchResultsEpisode, error) {
 	}
 
 	// Unauthorized
-	if resp.StatusCode == 401 {
-		return SearchResultsEpisode{}, errors.New("You are not authorized to access that server")
+	if resp.StatusCode == http.StatusUnauthorized {
+		return SearchResultsEpisode{}, errors.New("you are not authorized to access that server")
+	} else if resp.StatusCode != http.StatusOK {
+		return SearchResultsEpisode{}, errors.New("server error: " + resp.Status)
 	}
 
 	defer resp.Body.Close()


### PR DESCRIPTION
If a user has a subscription the `json.Unmarshal` would fail with an error message of:

"json: cannot unmarshal object into Go struct field SignInResponse.subscriptions of type string"

Do note that there may be some fields that need to be tested with non-lifetime membership

`RenewsAt`, `EndsAt` and `Type` are null when I sign in