### PR TITLE
Update UserPlexTV.AdsConsent* types

### DIFF
--- a/models.go
+++ b/models.go
@@ -584,9 +584,9 @@ type UserPlexTV struct {
 	PastSubscriptions    []string   `json:"pastSubscriptions"`
 	Trials               []string   `json:"trials"`
 	Services             []Services `json:"services"`
-	AdsConsent           string     `json:"adsConsent"`           // can be null
-	AdsConsentSetAt      string     `json:"adsConsentSetAt"`      // can be null
-	AdsConsentReminderAt string     `json:"adsConsentReminderAt"` // can be null
+	AdsConsent           bool       `json:"adsConsent"`           // can be null
+	AdsConsentSetAt      int        `json:"adsConsentSetAt"`      // can be null
+	AdsConsentReminderAt int        `json:"adsConsentReminderAt"` // can be null
 	ExperimentalFeatures bool       `json:"experimentalFeatures"`
 	TwoFactorEnabled     bool       `json:"twoFactorEnabled"`
 	BackupCodesCreated   bool       `json:"backupCodesCreated"`


### PR DESCRIPTION
plex.tv is returning different types for
* `adsConsent` (used to be string, now bool)
* `adsConsentSetAt` (used to be string, now int)
* `adsConsentReminderAt` (used to be string, now int).

This breaks `SignIn` and `Plex.MyAccount`.

An example response is 

```json
{
  "adsConsent":true,
  "adsConsentSetAt":1613945192,
  "adsConsentReminderAt":1645481192
}
```