### PR TITLE
Fix: json: cannot unmarshal array into Go struct field Metadata.MediaContainer.Metadata.rating of type float64

### DIFF
--- a/models.go
+++ b/models.go
@@ -71,6 +71,7 @@ type Metadata struct {
 	ParentTitle           string       `json:"parentTitle"`
 	RatingCount           int          `json:"ratingCount"`
 	Rating                float64      `json:"rating"`
+	Ratings               []Rating     `json:"Rating"`
 	RatingKey             string       `json:"ratingKey"`
 	SessionKey            string       `json:"sessionKey"`
 	Summary               string       `json:"summary"`
@@ -136,7 +137,6 @@ type Media struct {
 	Height                int         `json:"height"`
 	ID                    json.Number `json:"id"`
 	OptimizedForStreaming boolOrInt   `json:"optimizedForStreaming"` // plex can return int (GetMetadata(), GetPlaylist()) or boolean (GetSessions()): 0 or 1; true or false
-
 	Selected              bool        `json:"selected"`
 	VideoCodec            string      `json:"videoCodec"`
 	VideoFrameRate        string      `json:"videoFrameRate"`
@@ -893,4 +893,11 @@ type CurrentSessions struct {
 		Metadata []Metadata `json:"Metadata"`
 		Size     int        `json:"size"`
 	} `json:"MediaContainer"`
+}
+
+// Rating
+type Rating struct {
+	Image string      `json:"image"`
+	Type  string      `json:"type"`
+	Value json.Number `json:"value"`
 }


### PR DESCRIPTION
Getting an error on Plex 1.27.1.5916 `json: cannot unmarshal array into Go struct field Metadata.MediaContainer.Metadata.rating of type float64` during `GetSessions()`.

It seems that there is a new json field `Rating` that conflicts with the (deprecated?) existing `rating` which is float64.  An example response looks like this (trimmed for clarity):

```json
{
    "MediaContainer": {
        "size": 1,
        "Metadata": [
            {
                "parentTitle": "Season 6",
                "ratingKey": "5417",
                "sessionKey": "48",

                "Rating": [
                    {
                        "image": "themoviedb://image.rating",
                        "type": "audience",
                        "value": "7.7"
                    }
                ],

```

There is no float64 `rating`, but the new `Rating` array.   Golang json unmarshalling attempts case-sensitive field match first, but [falls back to case-insensitive](https://cs.opensource.google/go/go/+/refs/tags/go1.19.3:src/encoding/json/decode.go;l=43) and ends up colliding with `rating`.

This fix introduces a new `Rating` struct and the case-sensitive json name, however the go-field is `Ratings` to not conflict with the existing `Rating float64`.  