### PR TITLE
Add retrieval of playlists

### DIFF
--- a/cmd/README.md
+++ b/cmd/README.md
@@ -1,15 +1,37 @@
-### Commands
+# Example CLI
+
+This is an example CLI you can use to exercise the functionality in this Plex client library.
+
+## Executing
+
+To execute this program, run:
 
 ```
-     test         Test your connection to your Plex Media Server
-     end          End a transcode session
-     server-info  Print info about your servers - ip, machine id, access tokens,                                                                                             etc
-     sections     Print info about your server\'s sections
-     link         authorize an app (e.g. amazon fire app) with a 4 character `code`.
-                  REQUIRES a plex token
-     request-pin  request a pin (4 character code) from plex.tv to link account to an app.
-                  Use this to recieve an id to check for an auth token
-     check-pin    check status of pin (4 character code) from plex.tv to link account to an app.
-                  Use this to recieve an auth token. REQUIRES an id
-    library       Display libraries on your server
+go run .
 ```
+
+This will print a list of commands that can be executed.
+
+### Authentication
+
+Before interacting with your server, you will need to provision an access token. This can be done by one of two options:
+
+* **Set token** *(recommended)*: if you already know your access token (Plex [has documentation on how to find this](https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/)), you can initialize your access token by executing:
+
+```
+go run . token <token>
+```
+
+* **Username/password**: if you do not have [2FA enabled](https://support.plex.tv/articles/two-factor-authentication/) (and you should), if you execute the following, this will retrieve an access token for you:
+
+```
+go run . signin <username> <password>
+```
+
+Following that, you will need to select a server:
+
+```
+go run . pick-server
+```
+
+After this, you will be able to use the list of commands used to interact with your server.

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -962,7 +962,10 @@ func getPlaylists(c *cli.Context) error {
 		return err
 	}
 
-	fmt.Println(result)
+	fmt.Printf("%d playlists found\n", len(result))
+	for _, playlist := range result {
+		fmt.Printf("ID %d - '%s'\n", playlist.ID, playlist.Title)
+	}
 
 	return nil
 }

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -1032,3 +1032,29 @@ func deleteMedia(c *cli.Context) error {
 
 	return nil
 }
+
+func setToken(c *cli.Context) error {
+	db, err := startDB()
+
+	if err != nil {
+		return cli.NewExitError(err, 1)
+	}
+
+	defer db.Close()
+
+	if c.NArg() == 0 {
+		return cli.NewExitError("token is required", 1)
+	}
+
+	token := c.Args().First()
+
+	if isVerbose {
+		fmt.Println("saving token locally...")
+	}
+
+	if err := db.savePlexToken(token); err != nil {
+		return cli.NewExitError(err, 1)
+	}
+
+	return nil
+}

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -941,6 +941,32 @@ func downloadMedia(c *cli.Context) error {
 	return nil
 }
 
+func getPlaylists(c *cli.Context) error {
+	db, err := startDB()
+
+	if err != nil {
+		return cli.NewExitError(err, 1)
+	}
+
+	defer db.Close()
+
+	plexConn, err := initPlex(db, true, true)
+
+	if err != nil {
+		return err
+	}
+
+	result, err := plexConn.GetPlaylists()
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(result)
+
+	return nil
+}
+
 func getPlaylist(c *cli.Context) error {
 	db, err := startDB()
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -166,8 +166,13 @@ func main() {
 		},
 		{
 			Name:   "playlist",
-			Usage:  "print playlsit items on plex server",
+			Usage:  "print playlist items on plex server",
 			Action: getPlaylist,
+		},
+		{
+			Name:   "playlists",
+			Usage:  "print playlists on plex server",
+			Action: getPlaylists,
 		},
 		{
 			Name:  "delete",

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -185,6 +185,11 @@ func main() {
 				},
 			},
 		},
+		{
+			Name:   "token",
+			Usage:  "sets the plex token to be used for subsequent commands",
+			Action: setToken,
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {

--- a/models.go
+++ b/models.go
@@ -939,8 +939,11 @@ type Playlist struct {
 	UpdatedAt       time.Time
 }
 
-type playlistMediaContainer struct {
-	MediaContainer []*playlistResponse `json:"MediaContainer"`
+type playlistsResponse struct {
+	MediaContainer struct {
+		Metadata []*playlistResponse `json:"Metadata"`
+		Size     int                 `json:"size"`
+	} `json:"MediaContainer"`
 }
 
 type playlistResponse struct {
@@ -948,7 +951,7 @@ type playlistResponse struct {
 	Type         string `json:"type"`
 	Title        string `json:"title"`
 	Summary      string `json:"summary"`
-	Smart        int    `json:"smart"`
+	Smart        bool   `json:"smart"`
 	PlaylistType string `json:"playlistType"`
 	Composite    string `json:"composite"`
 	Icon         string `json:"icon"`

--- a/models.go
+++ b/models.go
@@ -913,3 +913,49 @@ type CurrentSessions struct {
 		Size     int        `json:"size"`
 	} `json:"MediaContainer"`
 }
+
+type PlaylistType string
+
+const (
+	PlaylistTypeAudio PlaylistType = "audio"
+	PlaylistTypePhoto PlaylistType = "photo"
+	PlaylistTypeVideo PlaylistType = "video"
+)
+
+type Playlist struct {
+	ID              int
+	MediaType       string
+	Title           string
+	Summary         string
+	IsSmartPlaylist bool
+	PlaylistType    PlaylistType
+	Composite       string
+	Icon            string
+	ViewCount       int
+	LastViewedAt    time.Time
+	Duration        time.Duration
+	ItemCount       int
+	AddedAt         time.Time
+	UpdatedAt       time.Time
+}
+
+type playlistMediaContainer struct {
+	MediaContainer []*playlistResponse `json:"MediaContainer"`
+}
+
+type playlistResponse struct {
+	RatingKey    string `json:"ratingKey"`
+	Type         string `json:"type"`
+	Title        string `json:"title"`
+	Summary      string `json:"summary"`
+	Smart        int    `json:"smart"`
+	PlaylistType string `json:"playlistType"`
+	Composite    string `json:"composite"`
+	Icon         string `json:"icon"`
+	ViewCount    int    `json:"viewCount"`
+	LastViewedAt int64  `json:"lastViewedAt"`
+	Duration     int    `json:"duration"`
+	LeafCount    int    `json:"leafCount"`
+	AddedAt      int64  `json:"addedAt"`
+	UpdatedAt    int64  `json:"updatedAt"`
+}

--- a/plex.go
+++ b/plex.go
@@ -410,14 +410,14 @@ func (p *Plex) GetPlaylists() ([]*Playlist, error) {
 
 	defer resp.Body.Close()
 
-	var playlistsContainer *playlistMediaContainer
+	var playlistsContainer *playlistsResponse
 
 	if err := json.NewDecoder(resp.Body).Decode(&playlistsContainer); err != nil {
 		return nil, err
 	}
 
-	playlists := make([]*Playlist, len(playlistsContainer.MediaContainer))
-	for playlistIndex, containerPlaylist := range playlistsContainer.MediaContainer {
+	playlists := make([]*Playlist, len(playlistsContainer.MediaContainer.Metadata))
+	for playlistIndex, containerPlaylist := range playlistsContainer.MediaContainer.Metadata {
 		playlistID, err := strconv.ParseInt(containerPlaylist.RatingKey, 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("unable to parse rating key '%s' into an integer", containerPlaylist.RatingKey)
@@ -427,7 +427,7 @@ func (p *Plex) GetPlaylists() ([]*Playlist, error) {
 			MediaType:       containerPlaylist.Type,
 			Title:           containerPlaylist.Title,
 			Summary:         containerPlaylist.Summary,
-			IsSmartPlaylist: containerPlaylist.Smart == 1,
+			IsSmartPlaylist: containerPlaylist.Smart,
 			PlaylistType:    PlaylistType(containerPlaylist.PlaylistType),
 			Composite:       containerPlaylist.Composite,
 			Icon:            containerPlaylist.Icon,

--- a/plex.go
+++ b/plex.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -390,6 +391,55 @@ func (p *Plex) Download(meta Metadata, path string, createFolders bool, skipIfEx
 	}
 
 	return nil
+}
+
+func (p *Plex) GetPlaylists() ([]*Playlist, error) {
+	query := fmt.Sprintf("%s/playlists", p.URL)
+
+	resp, err := p.get(query, p.Headers)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, errors.New(ErrorNotAuthorized)
+	} else if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf(ErrorServer, resp.Status)
+	}
+
+	defer resp.Body.Close()
+
+	var playlistsContainer *playlistMediaContainer
+
+	if err := json.NewDecoder(resp.Body).Decode(&playlistsContainer); err != nil {
+		return nil, err
+	}
+
+	playlists := make([]*Playlist, len(playlistsContainer.MediaContainer))
+	for playlistIndex, containerPlaylist := range playlistsContainer.MediaContainer {
+		playlistID, err := strconv.ParseInt(containerPlaylist.RatingKey, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse rating key '%s' into an integer", containerPlaylist.RatingKey)
+		}
+		playlists[playlistIndex] = &Playlist{
+			ID:              int(playlistID),
+			MediaType:       containerPlaylist.Type,
+			Title:           containerPlaylist.Title,
+			Summary:         containerPlaylist.Summary,
+			IsSmartPlaylist: containerPlaylist.Smart == 1,
+			PlaylistType:    PlaylistType(containerPlaylist.PlaylistType),
+			Composite:       containerPlaylist.Composite,
+			Icon:            containerPlaylist.Icon,
+			ViewCount:       containerPlaylist.ViewCount,
+			LastViewedAt:    time.Unix(containerPlaylist.LastViewedAt/1000, 0),
+			Duration:        time.Duration(containerPlaylist.Duration) * time.Millisecond,
+			AddedAt:         time.Unix(containerPlaylist.AddedAt/1000, 0),
+			UpdatedAt:       time.Unix(containerPlaylist.UpdatedAt/1000, 0),
+		}
+	}
+
+	return playlists, nil
 }
 
 // GetPlaylist gets all videos in a playlist.


### PR DESCRIPTION
This PR:

* Adds a new `GetPlaylists` method to the client to retrieve playlists from Plex
* Adds to the CLI the ability to set an access token as well as get and print the playlists
* Updates the README to include instructions on how to use the CLI, as well as removing the out-of-date listing of its supported commands

This was tested by locally running the following commands within the `cmd/` folder:

```
go run . token <redacted>

go run . pick-server
// picked a server

go run . playlists
26 playlists found
ID 185139 - '❤️ Tracks'
ID 185138 - 'All Music'
ID 185140 - 'Fresh ❤️'
ID 174514 - 'Recently Added'
...

go run . playlist 174514 
// list of items in the 'Recently Added' playlist
```