### PR TITLE
Add ability to download seasons

### DIFF
--- a/models.go
+++ b/models.go
@@ -47,6 +47,7 @@ type Metadata struct {
 	User                  User         `json:"User"`
 	AddedAt               int          `json:"addedAt"`
 	Art                   string       `json:"art"`
+	ChildCount            int          `json:"childCount"`
 	ContentRating         string       `json:"contentRating"`
 	Duration              int          `json:"duration"`
 	GrandparentArt        string       `json:"grandparentArt"`


### PR DESCRIPTION
Adds the ability to download seasons using the existing `plex-cli download` command by checking if the first selection has children, and if so, allowing the user to choose which child to download all files below, then iterating through the elements of the choice.

It does make assumptions around a single level of children, but should fail the same as choosing a series in the current version.