### PR TITLE
Fix parsing rating in metadata

### DIFF
--- a/models.go
+++ b/models.go
@@ -70,7 +70,7 @@ type Metadata struct {
 	ParentThumb           string       `json:"parentThumb"`
 	ParentTitle           string       `json:"parentTitle"`
 	RatingCount           int          `json:"ratingCount"`
-	Rating                float64      `json:"rating"`
+	Rating                []Rating     `json:"rating"`
 	RatingKey             string       `json:"ratingKey"`
 	SessionKey            string       `json:"sessionKey"`
 	Summary               string       `json:"summary"`
@@ -122,6 +122,13 @@ func (b *boolOrInt) UnmarshalJSON(data []byte) error {
 	b.bool = isBool
 
 	return nil
+}
+
+// Rating ...
+type Rating struct {
+	Image string  `json:"image"`
+	Value float64 `json:"value"`
+	Type  string  `json:"type"`
 }
 
 // Media media info


### PR DESCRIPTION
I was getting an error when parsing rating in metadata. 

Plex updated the response from the API:
<img width="833" height="205" alt="2026-01-25-173716_hyprshot" src="https://github.com/user-attachments/assets/eda1f76c-6fff-4489-8d4a-9f81acd32b2e" />

 This adds the type Media and parsing now works.