### PR TITLE
Remove debug print statements in websocket client

### DIFF
--- a/websocket_client.go
+++ b/websocket_client.go
@@ -241,8 +241,6 @@ func (p *Plex) SubscribeToNotifications(events *NotificationEvents, interrupt <-
 				return
 			}
 
-			fmt.Printf("%s\n", message)
-
 			var notif WebsocketNotification
 
 			if err := json.Unmarshal(message, &notif); err != nil {
@@ -250,7 +248,6 @@ func (p *Plex) SubscribeToNotifications(events *NotificationEvents, interrupt <-
 				continue
 			}
 
-			// fmt.Println(notif.Type)
 			fn, ok := events.events[notif.Type]
 
 			if !ok {


### PR DESCRIPTION
Remove debug print statements for message and notification type.

Just noticed whilst playing around with the library and the websocket notifications that I was getting spammed with message contents.

I'd like to see a push towards using a logger rather than fmt.Print as well but that'll be a bigger thing to attempt I'm sure.